### PR TITLE
reset item list for future uploads.

### DIFF
--- a/js/multiupload.js
+++ b/js/multiupload.js
@@ -71,6 +71,7 @@ function multiUploader(config){
 			data.append('file',file[f]);
 			data.append('index',ids);
 			$(".dfiles[rel='"+ids+"']").find(".progress").show();
+            var that = this;
 			$.ajax({
 				type:"POST",
 				url:this.config.uploadUrl,
@@ -88,7 +89,9 @@ function multiUploader(config){
 					});
 					if (f+1 < file.length) {
 						self._uploader(file,f+1);
-					}
+					} else {
+                        that.items = [];that.all = [];
+                    }
 				}
 			});
 		} else


### PR DESCRIPTION
There is a bug say first time you upload 2 files, after submission, you upload 3 more files. It is expected to only upload 3 files, but actually it uploads 2+3 = 5 files...

This fix is to reset the item list.